### PR TITLE
some edit

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,24 @@
+name: Check ruff format
+
+on:
+  push:
+    branches: [ "*" ]
+  pull_request:
+    branches: [ "*" ]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.10"
+    - name: Install ruff
+      run: |
+        python -m pip install --upgrade pip
+        pip install ruff
+    - name: Check code format with ruff
+      run: |
+        ruff format --check rbrapi

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 __pycache__/
-.ruff_cache/
 dist/
 rbrapi.egg-info/
 test.py

--- a/rbrapi/types.py
+++ b/rbrapi/types.py
@@ -1,4 +1,4 @@
-from json import loads
+from json import loads, dumps
 
 from typing import TypedDict, Dict, List
 
@@ -7,6 +7,20 @@ class APIResponse:
     def __init__(self, **kwargs):
         for key, value in kwargs.items():
             setattr(self, key, value)
+
+    def __str__(self) -> str:
+        return dumps(
+            {
+                "_": self.__class__.__name__,
+                **{
+                    attr: (getattr(self, attr))
+                    for attr in filter(lambda x: not x.startswith("_"), self.__dict__)
+                    if getattr(self, attr) is not None
+                },
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
 
     @classmethod
     def from_dict(cls, data: Dict[str, str]) -> "APIResponse":


### PR DESCRIPTION
### - 1: Add pretty print for types:
```python
from rbrapi.types import LootBoxResponses

print(
    LootBoxResponses(
        "123456789",
        False
    )
)
```

- The result before:
`<rbrapi.types.LootBoxResponses object at 0x7f83c267daf0>`
- The result now:
```json
{
  "_": "LootBoxResponses",
  "award_id": "123456789",
  "is_new": false
}
```

### - 2 : Remove .ruff_cache from .gitignore:
- it's automatically ignored by git.

### - 3 : Add ruff checker to workflows.
- for new commits/pull requests